### PR TITLE
[WIP] Enhanced main.tex

### DIFF
--- a/src/main.tex
+++ b/src/main.tex
@@ -1,77 +1,119 @@
-% following this guide 
-% https://www.overleaf.com/learn/latex/How_to_Write_a_Thesis_in_LaTeX_(Part_1):_Basic_Structure
-
-\documentclass[12pt]{book} 
-\usepackage{biblatex} 
-\usepackage{graphicx} % for images
-\usepackage{amsmath} %for big math definitions, enables \[  \]
-\usepackage{amssymb} %for common sets as real, complex, etc
-\usepackage{graphicx} %for insert images
-\usepackage{multicol} %for multicolumns
-\usepackage{cancel} %to cancel math terms
-\usepackage{float} % to use the H param in tables and fix his position
-\usepackage{hyperref} % to make listofcontent clickable
-\usepackage{tcolorbox} % to put te inside box
-
-%%%%%%%%%%%%%%%%%%%%%%% list of packages to remove before release
-\usepackage[figcolor=white]{todonotes}
-%\todo[inline]{A todonote placed in the text}
-%%%%%%%%%%%%%%%%%%%%%%%
-
-\addbibresource{bib/biblatex.bib}
-\graphicspath{ {./images/} }
-\restylefloat{table} % allow the tables to use the H param
+%%%%%%% Layout definitions
+\documentclass[fontsize=12pt,paper=letter,headings=big,chapterprefix=off,DIV=calc,headsepline=true,titlepage=on,BCOR=5mm,parskip=half*,appendixprefix=true]{scrbook} 			% an enhanced class for create books, part of the KOMA Script bundle
+\usepackage[utf8]{inputenc}			% for the correct typesetting of the document 
+\usepackage[T1]{fontenc}			% for ensure the correct typographical mapping of the text inserted in the generated PDF
+\usepackage[english]{babel}			% for ensure a correct justification and hyphenation of the text in the language used
+\usepackage[style=american]{csquotes} % for the correct typesetting of the quote marks.
+\usepackage[sfdefault,lining]{FiraSans} % for use a typeface other than Computer Modern typeface, 'sfdefault' activates Fira Sans as the default text font
+\usepackage{FiraMono}				% for monospaced text in URLS, code snippets, etc.
+\usepackage{amsmath} 				% for a lot of stuff that ease the mathematical typesetting
+\usepackage{amssymb} 				% for common sets as real, complex, etc.
+\usepackage{cancel} 				% to cancel math terms
+%%%%%%% Floats definitions
+\usepackage{multicol} 				% for multicolumns
+\usepackage{float} 					% to use the H parameter in tables and try to fix its position
+\restylefloat{table} 				% allow the tables to use the H parameter
+\usepackage{tcolorbox} 				% to put te inside box
+\usepackage{graphicx} 				% for insert images
+\graphicspath{{./images/}}			% path for search the images
+%%%%%%% References
+\usepackage{biblatex} 				% a 21st century citation and bibliographic reference insertion system
+\addbibresource{bib/biblatex.bib}	% the path to the reference database
+% If we don't setup anything else, the citation style and references at the end of the document will be the default ones used by the biblatex package.
+%%%%%%% Hyperlinks definitions
+\usepackage{hyperref} 				% to make listofcontent clickable and custom the PDF metadata 
 \hypersetup{
-    colorlinks,
-    citecolor=black,
-    filecolor=black,
-    linkcolor=black,
-    urlcolor=black
+pdftoolbar=true,        			% show Acrobat’s toolbar?
+    pdfmenubar=true,        		% show Acrobat’s menu?
+    pdffitwindow=false,     		% window fit to page when opened
+    pdfstartview={FitH},    		% fits the width of the page to the window
+    pdftitle={Statistics for Data Science},	% title
+    pdfauthor={Ricardo Hortelano},  % author
+    pdfsubject={Data Science},   	% subject of the document
+    pdfcreator={},   				% creator of the document
+    pdfproducer={}, 				% producer of the document
+    pdfkeywords={} {} {} {}, 		% list of keywords
+    pdfnewwindow=true,      		% links in new window
+    colorlinks=true,       			% false: boxed links; true: colored links
+    linkcolor=black,          		% color of internal links (change box color with linkbordercolor), by default red
+    citecolor=black,        		% color of links to bibliography, by default green
+    filecolor=black,      			% color of file links, by default magenta
+    urlcolor=black           		% color of external links, by default cyan
 }
 
-\addbibresource{bib/biblatex.bib}
+%%%%%%% ToDo definitions 
+\usepackage[figcolor=white,textsize=footnotesize]{todonotes} % General definitions for the todonotes package
 
+\newcommand{\didit}[1]{\todo[color=red!40]{#1}} % for task to do completed
+
+\newcommand{\addref}{\todo[color=red!90]{[Missing cite]}} % for add a missing reference 
+\newcommand{\rewrite}[1]{\todo[color=green!40]{#1}} % for a word, sentence or paragraph that has to be rewritten
+
+\makeatletter
+\if@todonotes@disabled
+\newcommand{\hlfix}[2]{#1}
+\else
+\newcommand{\hlfix}[2]{\texthl{#1}\todo{#2}} % snippet to highlight a text that needs to be revised in case of doubt in the face of a possible error
+\fi
+\makeatother% 
+
+%%%%%%% Microtypographical detaisl definitions 
+
+\raggedbottom
+\clubpenalty=10000
+\widowpenalty=10000
+
+%%%%%%% Title page defintions
+
+\extratitle{Statistics for Data Science}
+\titlehead{\itshape Release:\\
+ \input{version}}
+\subject{}
+\title{Statistics for Data Science}
+%\subtitle{}
+\author{Ricardo Hortelano}
+\date{2019}
+%\publishers{}
+
+\uppertitleback{\small
+Copyright \copyright ~2019 Ricardo Hortelano.\\
+}
+
+\lowertitleback{{\small
+Permission is granted to copy, distribute, and/or modify this document under the terms of the Creative Commons Attribution-NonCommercial 3.0 Unported License, which is available at \url{http://creativecommons.org/licenses/by-nc/3.0/}.\\
+
+The original form of this book is \LaTeX\ source code.  Compiling this \LaTeX\ source has the effect of generating a device-independent representation of a textbook, which can be converted to other formats and printed.\\
+
+The \LaTeX\ source for this book is available from \url{https://github.com/RicardoHS/statistics-for-data-science-book/}}
+}
+\dedication{To my right thumb}
+
+%%%%%% End of the preamble and start of the document
 \begin{document}
+\frontmatter % In LaTeX classes to make books such as this, book or memoir, this statement is used to start the numeration in Romans of all material prior to the chapters. It has the advantage that it allows us to insert chapters that are added to the Table of Contents and are not numbered.
 
-\begin{titlepage}
-    \vspace*{\stretch{1.0}}
-    \begin{center}
-       \Large\textbf{Statistics for Data Science}\\
-       \large\textit{Ricardo Hortelano}\\
-       \textit{2019}\\
-       \vspace*{3\baselineskip}
-       \textit{Release:}\\
-       \textit{\input{version}}
-    \end{center}
-    \vspace*{\stretch{2.0}}
- \end{titlepage}
+\maketitle
 
-%%%%%%%%%%%%%%%%%%%%%% to remove before release
-\listoftodos
-%%%%%%%%%%%%%%%%%%%%%%
 \tableofcontents
 
-\chapter*{Preface}
-\input{chapters/preface}
+\listoftodos % Can be commented on once all issues have been solved
 
-\chapter*{Introduction}
-\input{chapters/introduction}
+\input{chapters/preface.tex}
+\input{chapters/introduction.tex}
 
-\chapter{Linear Algebra}
-\input{chapters/linear_algebra}
+\mainmatter % This statement indicates that we are going to start the chapters and restarts the counter to 1 and begins to enumerate in arabics.
 
-\chapter{Probability}
-\input{chapters/probability}
+\input{chapters/linear_algebra.tex}
+\input{chapters/probability.tex}
+\input{chapters/inference.tex}
+\end{document}
+\input{chapters/num_methods.tex}
 
-\chapter{Statistical Inference}
-\input{chapters/inference}
-
-\chapter{Numerical Methods}
-\input{chapters/num_methods}
+\backmatter % This statement serves the final material of the book as analytical indexes, onomastics, references, appendices and annexes. However, it doesn't modify the numbering of the pages.
 
 \appendix
-\chapter{Appendix}
-\input{chapters/appendix}
 
-\printbibliography
+\input{chapters/appendix.tex}
+
+%\printbibliography
 \end{document}


### PR DESCRIPTION
# Overview

I remake the preamble entirely to move from the class `book` to the class `scrbook` belonging to the [KOMA Script bundle](https://www.ctan.org/pkg/koma-script). 

I added comments to all the lines important to understand what the code does and to justify in that way the pertinence of the use of the code I propose.

The reason I propose this class is because I find several advantages that I list below:

1. It saves the use of certain packages like `geometry`, `epigraph`, etc.;
2. Corrects bugs that the `book` class still has;
3. Integrates organically without the need to add snippets the bibliography to the Table of Contents and the unnumbered chapters in the frontmatter;
4. Allows you to adjust the margins to your liking by varying the value of the `DIV` parameter in a range of integer values from 6 to 15;
5. KOMA Script supports a much larger variety of paper sizes than standard classes such as book, as well as the ability to use custom sizes without problems;
6. It allows to avoid the word "Chapter" at the beginning of each chapter and offers 3 different sizes for the headings
7. It adds a binding correction factor (`BCOR`) that allows you to readjust the typographic boxes to the value of that factor so that once the book is bound, there is no text too close to the spine that is difficult to read. I have not seen anything like this in other LaTeX classes for making books, nor in ConTeXt.

# Layout

One of the details present in most of the books typesetted in LaTeX, is that "vanilla" layout using the default formatting options.

That is why I propose the Fira Sans/Fira Mono typefaces, because they also has support for the mathematical text necessary to write this book. I hope you like the choice, but if you don't, you can modify it to your liking.

## Some additional enhancements

To avoid potential problems with coding and mapping typefaces when compiling and creating the PDF I have added the `inputenc` and `fontenc` packages. And while LaTeX can be used directly to create documents in English, I chose to add the `babel` package to ensure the correct hyphenation in that language.

# Additional issues

In addition to removing the duplicate packages and giving a more coherent order to the packages and their options in the preamble, I have noticed some inconsistencies that I consider pertinent to break down in order to resolve them and avoid them in the remaining material of the book that is about to be written.

## About maths

If we declare the package amsmath we must use it

Amsmath is used for more than _big math definitions and enable `\[ \]`_, it is a package that makes our life much easier when typesetting maths.

I prefer to use the `equation*` environment instead of `\[ \]` to typeset an equation displayed outside the paragraph. It has the advantage that the _star_ can be removed and numbered and that it makes the document more _readable_.

About fractions, is not that `\frac` is wrong, but in `amsmath` we can use `\dfrac` if the equation is dislpayed out of paragraph and `\tfrac` if we want to insert a fraction inside the paragraph.

`amsmath` also offers us several very useful environments to compose sets of equations that we can use.

## About structure

Don't forget that the structure in a book is:

1. chapter
2. section
3. subsection
4. subsubsection
5. paragraph
6. subparagraph

Above all because if we skip a level, at the end we'll get a horrible zero in the numbering, something that is wrong.

I also saw that instead of using `paragraph` or `paragraph*` has been put in boldface that I assume is some kind of header. If my assumption is correct, it would be worth using `\minisec` which is one more KOMA Script option that allows you to place a header without it being numbered or indexed in the table of contents.

I think that for now is enough observations, I will upload the modified files to the branch and add the notes of the `todonotes` pacakge relevant to show punctually the observations I comment.